### PR TITLE
ItemReader/Writer implementations for Dynamo DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The following is a list of reusable components in `jberet-support`:
     * [NoMappingJsonFactoryObjectFactory](https://github.com/jberet/jsr352/blob/master/jberet-support/src/main/java/org/jberet/support/io/NoMappingJsonFactoryObjectFactory.java)
     * [XmlFactoryObjectFactory](https://github.com/jberet/jsr352/blob/master/jberet-support/src/main/java/org/jberet/support/io/XmlFactoryObjectFactory.java)
 
+* DynamoDB (AWS NoSQL database)
+  * [DynamoDbItemReader](https://github.com/jberet/jsr352/blob/master/jberet-support/src/main/java/org/jberet/support/io/DynamoDbItemReader.java)
+  * [DynamoDbItemWriter](https://github.com/jberet/jsr352/blob/master/jberet-support/src/main/java/org/jberet/support/io/DynamoDbItemWriter.java)
+
 ### Documentation
 
 [JBeret Docs](http://docs.jboss.org/jberet/) contains JBeret User Guide and
@@ -78,20 +82,40 @@ The following is a list of reusable components in `jberet-support`:
 All tests in this module run batch jobs in Java SE environment, and therefore
 no application server is needed. There are 2 maven profiles for different testing setup:
 
-* `allTests`: include tests that need `MongoDB` server running, and so users will need to
-start MongoDB server before running these tests;
+* `allTests`: include tests that need `MongoDB` and `DynamoDbLocal` server running.
+  So users will need to start MongoDB
+  and [DynamoDb Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) servers
+  before running these tests.
+  A `docker-compose.yml` is provided to easily start those servers.
 * `default`: exclude all tests that need additional server running.
 
 To clean, build, and run the default maven profile:
 
+```
     mvn clean install
+```
 
 To clean, build, and run `allTests` maven profile:
 
-    [in a separate terminal]
-    $MONGO_HOME/bin/mongod
+```
+    [in a Mongo terminal]
+    $MONGO_HOME/bin/mongod   
+
+    [in a DynamoDB terminal]
+    export AWS_ACCESS_KEY_ID="JBeret"
+    export AWS_SECRET_ACCESS_KEY="JBeret"
+    export AWS_REGION="eu-west-1"   
+    java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb
     
     mvn clean install -PallTests -Djberet.tmp.dir=/tmp
+```
+
+Or with Docker compose
+
+```
+    docker-compose up -d    
+    mvn clean install -PallTests -Djberet.tmp.dir=/tmp
+```
 
 ### Other Examples
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  # Used by MongoItemReaderTest
+  mongodb:
+    image: mongo:6-jammy
+    container_name: mongodb
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb-data:/data/db:rw
+    environment:
+      MONGO_INITDB_DATABASE: testData
+  dynamodb-local:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:2.0.0"
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    volumes:
+      - dynamodb-data:/home/dynamodblocal/data:rw
+    working_dir: /home/dynamodblocal
+    environment:
+      AWS_ACCESS_KEY_ID: JBeret
+      AWS_SECRET_ACCESS_KEY: JBeret
+      AWS_REGION: eu-west-1
+volumes:
+  mongodb-data:
+    driver: local
+  dynamodb-data:
+    driver: local

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
         <version.org.beanio>2.1.0</version.org.beanio>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
+        <version.software.amazon.awssdk>2.20.152</version.software.amazon.awssdk>
     </properties>
 
     <dependencyManagement>
@@ -107,6 +108,14 @@
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${version.org.ow2.asm}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- DynamoDB dependencies -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>dynamodb-enhanced</artifactId>
+                <version>${version.software.amazon.awssdk}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>
@@ -258,6 +267,12 @@
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
+        <!-- DynamoDB dependencies -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb-enhanced</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.jberet</groupId>
@@ -369,6 +384,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/Mongo*.java</exclude>
+                                <exclude>**/DynamoDb*.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/src/main/java/org/jberet/support/io/DynamoDbItemReadWriterBase.java
+++ b/src/main/java/org/jberet/support/io/DynamoDbItemReadWriterBase.java
@@ -20,89 +20,119 @@ import java.net.URI;
  * @see DynamoDbItemWriter
  */
 public class DynamoDbItemReadWriterBase<D> {
-	/**
-	 * CDI provided {@link DynamoDbEnhancedClient}
-	 */
-	@Inject
-	protected Instance<DynamoDbEnhancedClient> enhancedClientInstance;
+    /**
+     * CDI provided {@link DynamoDbEnhancedClient}
+     */
+    @Inject
+    protected Instance<DynamoDbClient> clientInstance;
 
-	/**
-	 * Dynamo DB endpoint URI.
-	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
-	 */
-	@Inject
-	@BatchProperty
-	protected String endpointUri;
-	/**
-	 * Dynamo DB access key Id.
-	 * By default, connection to DynamoDb uses default credential provided: environment variables,
-	 * Java system properties, and AWS profile are supported.
-	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
-	 */
-	@Inject
-	@BatchProperty
-	protected String accessKeyId;
-	/**
-	 * Dynamo DB secret access key.
-	 * By default, connection to DynamoDb uses default credential provided: environment variables,
-	 * Java system properties, and AWS profile are supported.
-	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
-	 */
-	@Inject
-	@BatchProperty
-	protected String secretAccessKey;
-	/**
-	 * AWS region, see {@link  Region}
-	 */
-	@Inject
-	@BatchProperty
-	protected String region;
-	/**
-	 * Effective instance of {@link DynamoDbEnhancedClient}
-	 */
-	protected DynamoDbEnhancedClient enhancedClient;
-	/**
-	 * Bean class used for table / object mapping
-	 */
-	@Inject
-	@BatchProperty
-	protected Class<D> beanClass;
-	/**
-	 * Target Dynamo DB table
-	 */
-	@Inject
-	@BatchProperty
-	protected String tableName;
+    /**
+     * CDI provided {@link DynamoDbEnhancedClient}
+     */
+    @Inject
+    protected Instance<DynamoDbEnhancedClient> enhancedClientInstance;
 
-	public DynamoDbTable<D> getTable() {
-		return enhancedClient.table(tableName, TableSchema.fromBean(beanClass));
-	}
+    /**
+     * Dynamo DB endpoint URI.
+     * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+     */
+    @Inject
+    @BatchProperty
+    protected String endpointUri;
+    /**
+     * Dynamo DB access key Id.
+     * By default, connection to DynamoDb uses default credential provided: environment variables,
+     * Java system properties, and AWS profile are supported.
+     * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+     */
+    @Inject
+    @BatchProperty
+    protected String accessKeyId;
+    /**
+     * Dynamo DB secret access key.
+     * By default, connection to DynamoDb uses default credential provided: environment variables,
+     * Java system properties, and AWS profile are supported.
+     * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+     */
+    @Inject
+    @BatchProperty
+    protected String secretAccessKey;
+    /**
+     * AWS region, see {@link  Region}
+     */
+    @Inject
+    @BatchProperty
+    protected String region;
+    /**
+     * Effective instance of {@link DynamoDbClient}
+     */
+    protected DynamoDbClient client;
+    /**
+     * Effective instance of {@link DynamoDbEnhancedClient}
+     */
+    protected DynamoDbEnhancedClient enhancedClient;
+    /**
+     * Bean class used for table / object mapping
+     */
+    @Inject
+    @BatchProperty
+    protected Class<D> beanClass;
+    /**
+     * Target Dynamo DB table
+     */
+    @Inject
+    @BatchProperty
+    protected String tableName;
 
-	/**
-	 * Initialise {@link #enhancedClient} field either using {@link #enhancedClientInstance}
-	 * or creating a specific one.
-	 */
-	protected void initEnhancedClient() {
-		if (enhancedClient != null) {
-			return;
-		}
-		if (enhancedClientInstance == null || enhancedClientInstance.isUnsatisfied()) {
-			DynamoDbClientBuilder baseClientBuilder = DynamoDbClient.builder();
-			if (endpointUri != null) {
-				baseClientBuilder = baseClientBuilder.endpointOverride(URI.create(endpointUri));
-			}
-			if (accessKeyId != null && secretAccessKey != null) {
-				baseClientBuilder = baseClientBuilder.credentialsProvider(() -> AwsBasicCredentials.create("JBeret", "JBeret"));
-			}
-			if (region != null) {
-				baseClientBuilder = baseClientBuilder.region(Region.of(region));
-			}
-			enhancedClient = DynamoDbEnhancedClient.builder()
-					.dynamoDbClient(baseClientBuilder.build())
-					.build();
-		} else {
-			// Externally provider client
-			enhancedClient = enhancedClientInstance.get();
-		}
-	}
+    public DynamoDbTable<D> getTable() {
+        return enhancedClient.table(tableName, TableSchema.fromBean(beanClass));
+    }
+
+    /**
+     * Initialize {@link #client} and {@link #enhancedClient} field either using {@link #clientInstance} and {@link #enhancedClientInstance}
+     * or creating a specific one.
+     */
+    protected void initEnhancedClient() {
+        if (enhancedClient == null) {
+            if (enhancedClientInstance == null || enhancedClientInstance.isUnsatisfied()) {
+                initClient();
+                enhancedClient = DynamoDbEnhancedClient.builder()
+                        .dynamoDbClient(client)
+                        .build();
+            } else {
+                // Externally provider client
+                enhancedClient = enhancedClientInstance.get();
+            }
+        }
+    }
+
+    /**
+     * Initialize {@link #client}  field either using {@link #clientInstance}
+     * or creating a specific one.
+     */
+    protected void initClient() {
+        if (client == null) {
+            if (clientInstance == null || clientInstance.isUnsatisfied()) {
+                DynamoDbClientBuilder baseClientBuilder = DynamoDbClient.builder();
+                if (endpointUri != null) {
+                    baseClientBuilder = baseClientBuilder.endpointOverride(URI.create(endpointUri));
+                }
+                if (accessKeyId != null && secretAccessKey != null) {
+                    baseClientBuilder = baseClientBuilder.credentialsProvider(this::awsBasicCredentials);
+                }
+                if (region != null) {
+                    baseClientBuilder = baseClientBuilder.region(Region.of(region));
+                }
+                client = baseClientBuilder.build();
+            } else {
+                // Externally provider client
+                client = clientInstance.get();
+            }
+
+        }
+    }
+
+    private AwsBasicCredentials awsBasicCredentials() {
+        return AwsBasicCredentials.create(this.accessKeyId, this.secretAccessKey);
+    }
 }

--- a/src/main/java/org/jberet/support/io/DynamoDbItemReadWriterBase.java
+++ b/src/main/java/org/jberet/support/io/DynamoDbItemReadWriterBase.java
@@ -1,0 +1,108 @@
+package org.jberet.support.io;
+
+import jakarta.batch.api.BatchProperty;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+import java.net.URI;
+
+/**
+ * The base class for {@link DynamoDbItemReader} and {@link DynamoDbItemWriter}.
+ *
+ * @see DynamoDbItemReader
+ * @see DynamoDbItemWriter
+ */
+public class DynamoDbItemReadWriterBase<D> {
+	/**
+	 * CDI provided {@link DynamoDbEnhancedClient}
+	 */
+	@Inject
+	protected Instance<DynamoDbEnhancedClient> enhancedClientInstance;
+
+	/**
+	 * Dynamo DB endpoint URI.
+	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+	 */
+	@Inject
+	@BatchProperty
+	protected String endpointUri;
+	/**
+	 * Dynamo DB access key Id.
+	 * By default, connection to DynamoDb uses default credential provided: environment variables,
+	 * Java system properties, and AWS profile are supported.
+	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+	 */
+	@Inject
+	@BatchProperty
+	protected String accessKeyId;
+	/**
+	 * Dynamo DB secret access key.
+	 * By default, connection to DynamoDb uses default credential provided: environment variables,
+	 * Java system properties, and AWS profile are supported.
+	 * Only when no {@link DynamoDbEnhancedClient} is provided, mainly for DynamoDb Local testing
+	 */
+	@Inject
+	@BatchProperty
+	protected String secretAccessKey;
+	/**
+	 * AWS region, see {@link  Region}
+	 */
+	@Inject
+	@BatchProperty
+	protected String region;
+	/**
+	 * Effective instance of {@link DynamoDbEnhancedClient}
+	 */
+	protected DynamoDbEnhancedClient enhancedClient;
+	/**
+	 * Bean class used for table / object mapping
+	 */
+	@Inject
+	@BatchProperty
+	protected Class<D> beanClass;
+	/**
+	 * Target Dynamo DB table
+	 */
+	@Inject
+	@BatchProperty
+	protected String tableName;
+
+	public DynamoDbTable<D> getTable() {
+		return enhancedClient.table(tableName, TableSchema.fromBean(beanClass));
+	}
+
+	/**
+	 * Initialise {@link #enhancedClient} field either using {@link #enhancedClientInstance}
+	 * or creating a specific one.
+	 */
+	protected void initEnhancedClient() {
+		if (enhancedClient != null) {
+			return;
+		}
+		if (enhancedClientInstance == null || enhancedClientInstance.isUnsatisfied()) {
+			DynamoDbClientBuilder baseClientBuilder = DynamoDbClient.builder();
+			if (endpointUri != null) {
+				baseClientBuilder = baseClientBuilder.endpointOverride(URI.create(endpointUri));
+			}
+			if (accessKeyId != null && secretAccessKey != null) {
+				baseClientBuilder = baseClientBuilder.credentialsProvider(() -> AwsBasicCredentials.create("JBeret", "JBeret"));
+			}
+			if (region != null) {
+				baseClientBuilder = baseClientBuilder.region(Region.of(region));
+			}
+			enhancedClient = DynamoDbEnhancedClient.builder()
+					.dynamoDbClient(baseClientBuilder.build())
+					.build();
+		} else {
+			// Externally provider client
+			enhancedClient = enhancedClientInstance.get();
+		}
+	}
+}

--- a/src/main/java/org/jberet/support/io/DynamoDbItemReader.java
+++ b/src/main/java/org/jberet/support/io/DynamoDbItemReader.java
@@ -1,0 +1,267 @@
+package org.jberet.support.io;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemReader;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+/**
+ * An implementation of {@code jakarta.batch.api.chunk.ItemRead} that scans or queries items from DynamoDB.
+ */
+@Named
+@Dependent
+public class DynamoDbItemReader<D> extends DynamoDbItemReadWriterBase<D> implements ItemReader {
+	/**
+	 * When indexName is set, the given index is read.
+	 * When indexName is not set, the whole table is read.
+	 */
+	@Inject
+	@BatchProperty
+	protected String indexName;
+	/**
+	 * When partition key is set, a query on given partition is issued.
+	 * When partition key is not set, a scan on the whole table is issued.
+	 */
+	@Inject
+	@BatchProperty
+	protected String partitionKey;
+	/**
+	 * Consistent read flag
+	 */
+	@Inject
+	@BatchProperty
+	protected Boolean consistentRead;
+	/**
+	 * Number of items to skip at the beginning
+	 */
+	@Inject
+	@BatchProperty
+	protected Integer start;
+	/**
+	 * Maximum number of items to retrieve
+	 */
+	@Inject
+	@BatchProperty
+	protected Integer end;
+	/**
+	 * Maximum number of items to read on server side
+	 */
+	@Inject
+	@BatchProperty
+	protected Integer limit;
+	/**
+	 * Filter expression.
+	 * Example: <code>price>=:minPrice and active=:active and #type=:type</code>
+	 */
+	@Inject
+	@BatchProperty
+	protected String filterExpression;
+	/**
+	 * Field nama aliases to inject in the {@link #filterExpression}.
+	 * This is a key-value map encoded in JSON.
+	 * Example: <code>{"#type":"type"}</code>
+	 */
+	@Inject
+	@BatchProperty
+	protected String filterExpressionNames;
+	/**
+	 * Values to inject in the {@link #filterExpression}.
+	 * This is a key-value map encoded in JSON.
+	 * Example: <code>{":minPrice":12,":active":true,":type":"candy"}</code>
+	 */
+	@Inject
+	@BatchProperty
+	protected String filterExpressionValues;
+	/**
+	 * Attributes to project in result bean.
+	 * This is a coma separated list of field names.
+	 * Example: <code>name,minPrice,active,type</code>
+	 */
+	@Inject
+	@BatchProperty
+	protected String attributesToProject;
+	/**
+	 * Current item iterator
+	 */
+	private Iterator<D> itemIterator;
+
+	@Override
+	public void open(Serializable serializable) throws Exception {
+		initEnhancedClient();
+		PageIterable<D> pageIterable = read(getTable());
+		Stream<D> itemStream = pageIterable.items().stream();
+		if (this.start != null && this.start >= 0) {
+			itemStream = itemStream.skip(this.start);
+		}
+		if (this.end != null && this.end > 0) {
+			itemStream = itemStream.limit(this.end - (this.start == null ? 0 : this.start));
+		}
+		itemIterator = itemStream.iterator();
+	}
+
+	private PageIterable<D> read(DynamoDbTable<D> table) {
+		Key queryKey = getQueryKey();
+		PageIterable<D> pageIterable;
+		if (this.indexName == null) {
+			if (queryKey == null) {
+				pageIterable = table.scan(this::configureScanRequest);
+			} else {
+				pageIterable = table.query(builder -> configureQueryRequest(builder, queryKey));
+			}
+		} else {
+			DynamoDbIndex<D> index = table.index(this.indexName);
+			if (queryKey == null) {
+				pageIterable = PageIterable.create(index.scan(this::configureScanRequest));
+			} else {
+				pageIterable = PageIterable.create(index.query(builder -> configureQueryRequest(builder, queryKey)));
+			}
+		}
+		return pageIterable;
+	}
+
+	private QueryEnhancedRequest.Builder configureQueryRequest(QueryEnhancedRequest.Builder builder, Key queryKey) {
+		return builder
+				.consistentRead(this.consistentRead)
+				.limit(this.limit)
+				.queryConditional(QueryConditional.keyEqualTo(queryKey))
+				.filterExpression(getFilterExpression());
+	}
+
+	private ScanEnhancedRequest.Builder configureScanRequest(ScanEnhancedRequest.Builder builder) {
+		return builder
+				.consistentRead(this.consistentRead)
+				.limit(this.limit)
+				.filterExpression(getFilterExpression())
+				.attributesToProject(getAttributesToProject());
+	}
+
+
+	@Override
+	public void close() throws Exception {
+
+	}
+
+	@Override
+	public D readItem() {
+		return itemIterator.hasNext() ? itemIterator.next() : null;
+	}
+
+	private Expression getFilterExpression() {
+		if (this.filterExpression == null) {
+			return null;
+		} else {
+			return Expression.builder()
+					.expression(this.filterExpression)
+					.expressionNames(getFilterExpressionNames())
+					.expressionValues(getFilterExpressionValues())
+					.build();
+		}
+	}
+
+	protected Map<String, String> getFilterExpressionNames() {
+		if (this.filterExpressionNames == null) {
+			return null;
+		}
+		try {
+			return new ObjectMapper().readValue(this.filterExpressionNames, new TypeReference<>() {
+			});
+		} catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Invalid filterExpressionNames JSON", e);
+		}
+	}
+
+	protected Map<String, AttributeValue> getFilterExpressionValues() {
+		if (this.filterExpressionValues == null) {
+			return Collections.emptyMap();
+		}
+		try {
+			ObjectNode objectNode = (ObjectNode) new ObjectMapper().readTree(this.filterExpressionValues);
+			return getAttributeValues(objectNode);
+		} catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Invalid filterExpressionValues JSON", e);
+		}
+	}
+
+	static Map<String, AttributeValue> getAttributeValues(ObjectNode objectNode) {
+		Map<String, AttributeValue> map = new HashMap<>(objectNode.size());
+		Iterator<Map.Entry<String, JsonNode>> fieldIter = objectNode.fields();
+		while (fieldIter.hasNext()) {
+			Map.Entry<String, JsonNode> field = fieldIter.next();
+			map.put(field.getKey(), getAttributeValue(field.getValue()));
+		}
+		return map;
+	}
+
+	private static List<AttributeValue> getAttributeValues(ArrayNode arrayNode) {
+		List<AttributeValue> list = new ArrayList<>(arrayNode.size());
+		for (JsonNode item : arrayNode) {
+			list.add(getAttributeValue(item));
+		}
+		return list;
+	}
+
+	private static AttributeValue getAttributeValue(JsonNode node) {
+		if (node == null || node.isNull()) {
+			return AttributeValue.fromNul(true);
+		} else if (node.isTextual()) {
+			return AttributeValue.fromS(node.textValue());
+		} else if (node.isNumber()) {
+			return AttributeValue.fromN(node.toString());
+		} else if (node.isBoolean()) {
+			return AttributeValue.fromBool(node.booleanValue());
+		} else if (node.isArray()) {
+			return AttributeValue.fromL(getAttributeValues((ArrayNode) node));
+		} else if (node.isObject()) {
+			return AttributeValue.fromM(getAttributeValues((ObjectNode) node));
+		}
+		return null;
+	}
+
+	private Collection<String> getAttributesToProject() {
+		if (this.attributesToProject == null) {
+			return null;
+		}
+		return Stream.of(this.attributesToProject.split(","))
+				.map(String::trim).collect(Collectors.toList());
+	}
+
+	private Key getQueryKey() {
+		if (partitionKey == null) {
+			return null;
+		}
+		return Key.builder().partitionValue(partitionKey).build();
+	}
+
+	@Override
+	public Serializable checkpointInfo() throws Exception {
+		return null;
+	}
+}

--- a/src/main/java/org/jberet/support/io/DynamoDbItemWriter.java
+++ b/src/main/java/org/jberet/support/io/DynamoDbItemWriter.java
@@ -1,0 +1,148 @@
+package org.jberet.support.io;
+
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.chunk.ItemWriter;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
+import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An implementation of {@code jakarta.batch.api.chunk.ItemWriter} that puts or deletes items to DynamoDB.
+ */
+@Named
+@Dependent
+public class DynamoDbItemWriter<D> extends DynamoDbItemReadWriterBase<D> implements ItemWriter {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	/**
+	 * Flag to indicate whether items should be created/update or deleted
+	 */
+	@Inject
+	@BatchProperty
+	protected boolean deleteItem;
+
+	/**
+	 * The maximum number of items per write batch is 25.
+	 * To avoid hitting this limit, items are writen making multiple requests of maximum 25 items.
+	 *
+	 * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html">APIBatchWriteItem documentation</a>
+	 */
+	private class InternalWriteBatch {
+		private final DynamoDbTable<D> table;
+		private WriteBatch.Builder<D> batchBuilder;
+		private int batchSize;
+		private final List<D> unprocessedPutItems = new ArrayList<>();
+		private final List<Key> unprocessedDeleteItems = new ArrayList<>();
+
+		private InternalWriteBatch() {
+			this.table = getTable();
+			newBatch();
+		}
+
+		private void newBatch() {
+			this.batchBuilder = WriteBatch.builder(beanClass).mappedTableResource(table);
+			this.batchSize = 0;
+		}
+
+		void addItem(Object item) {
+			addItemToBatch(item, this.batchBuilder);
+			this.batchSize++;
+			if (this.batchSize == 25) {
+				flush();
+			}
+		}
+
+		void flush() {
+			if (this.batchSize == 0) {
+				return;
+			}
+			// Execute batch
+			BatchWriteResult batchWriteResult = enhancedClient.batchWriteItem(BatchWriteItemEnhancedRequest.builder()
+					.addWriteBatch(batchBuilder.build())
+					.build());
+			// Check result
+			unprocessedPutItems.addAll(batchWriteResult.unprocessedPutItemsForTable(table));
+			unprocessedDeleteItems.addAll(batchWriteResult.unprocessedDeleteItemsForTable(table));
+			newBatch();
+		}
+
+	}
+
+	/**
+	 * Converts an item into batch element, either of type putItem or deleteItem.
+	 */
+	protected void addItemToBatch(Object item, WriteBatch.Builder<D> writeBatch) {
+		D typedItem = beanClass.cast(item);
+		if (shouldDeleteItem(typedItem)) {
+			writeBatch.addDeleteItem(typedItem);
+		} else {
+			writeBatch.addPutItem(typedItem);
+		}
+	}
+
+	/**
+	 * Determines whether item should deleted or put to batch.
+	 * This method can be overriden.
+	 */
+	protected boolean shouldDeleteItem(D item) {
+		return deleteItem;
+	}
+
+	@Override
+	public void open(Serializable serializable) {
+		initEnhancedClient();
+	}
+
+	@Override
+	public void writeItems(List<Object> items) {
+		InternalWriteBatch batch = new InternalWriteBatch();
+		items.forEach(batch::addItem);
+		batch.flush();
+		if (!batch.unprocessedPutItems.isEmpty()) {
+			handleUnprocessedPutItems(batch.unprocessedPutItems);
+		}
+		if (!batch.unprocessedDeleteItems.isEmpty()) {
+			handleUnprocessedDeleteItems(batch.unprocessedDeleteItems);
+		}
+	}
+
+	/**
+	 * Handles unprocessed delete items.
+	 * By default, unprocessed items are logged.
+	 * This method can be overriden.
+	 */
+	protected void handleUnprocessedDeleteItems(List<Key> unprocessedDeleteItems) {
+		logger.warn("{} unprocessed delete items", unprocessedDeleteItems.size());
+	}
+
+	/**
+	 * Handles unprocessed put items.
+	 * By default, unprocessed items are logged.
+	 * This method can be overriden.
+	 */
+	protected void handleUnprocessedPutItems(List<D> unprocessedPutItems) {
+		logger.warn("{} unprocessed put items", unprocessedPutItems.size());
+	}
+
+	@Override
+	public Serializable checkpointInfo() throws Exception {
+		return null;
+	}
+
+	@Override
+	public void close() throws Exception {
+
+	}
+
+}

--- a/src/main/java/org/jberet/support/io/DynamoDbTableBatchlet.java
+++ b/src/main/java/org/jberet/support/io/DynamoDbTableBatchlet.java
@@ -1,0 +1,181 @@
+package org.jberet.support.io;
+
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.Batchlet;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Named
+@Dependent
+public class DynamoDbTableBatchlet<D> extends DynamoDbItemReadWriterBase<D> implements Batchlet {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    /**
+     * Either delete, create, update or truncate
+     */
+    @Inject
+    @BatchProperty
+    String action;
+
+    public enum Action {
+        DELETE, CREATE, UPDATE, TRUNCATE
+    }
+
+    /**
+     * DynamoDB Local does not support some features like point in time recovery or tags
+     */
+    @Inject
+    @BatchProperty
+    boolean dynamoDbLocal;
+    @Inject
+    @BatchProperty
+    Long writeCapacityUnits;
+    @Inject
+    @BatchProperty
+    Long readCapacityUnits;
+    @Inject
+    @BatchProperty
+    List<String> globalSecondaryIndices;
+    @Inject
+    @BatchProperty
+    String kmsMasterKeyId;
+    @Inject
+    @BatchProperty
+    Boolean pointInTimeRecoveryEnabled;
+    @Inject
+    @BatchProperty
+    Map<String, String> tableTags;
+
+    private static <D> boolean tableExists(DynamoDbTable<D> table) {
+        try {
+            table.describeTable();
+            return true;
+        } catch (ResourceNotFoundException tableNotFoundExc) {
+            return false;
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+
+    }
+
+    @Override
+    public String process() {
+        if (action == null || action.isEmpty()) {
+            return BatchStatus.COMPLETED.name();
+        }
+        initClient();
+        initEnhancedClient();
+        DynamoDbTable<D> table = getTable();
+        boolean tableExists = tableExists(table);
+        switch (Action.valueOf(action.toUpperCase())) {
+            case DELETE:
+                if (tableExists) {
+                    doDelete(table);
+                }
+                break;
+            case CREATE:
+                if (!tableExists) {
+                    doCreate(table);
+                }
+                doUpdate();
+                break;
+            case UPDATE:
+                if (tableExists) {
+                    doUpdate();
+                }
+                break;
+            case TRUNCATE:
+                if (tableExists) {
+                    doDelete(table);
+                }
+                doCreate(table);
+                doUpdate();
+        }
+        return BatchStatus.COMPLETED.name();
+    }
+
+    private void doDelete(DynamoDbTable<D> table) {
+        logger.warn("Deleting table {}", tableName);
+        table.deleteTable();
+        client.waiter().waitUntilTableNotExists(DescribeTableRequest.builder().tableName(tableName).build());
+    }
+
+    private void doCreate(DynamoDbTable<D> table) {
+        logger.warn("Creating table {}", tableName);
+        CreateTableEnhancedRequest.Builder createRequest = CreateTableEnhancedRequest.builder();
+        if (globalSecondaryIndices != null && !globalSecondaryIndices.isEmpty()) {
+            createRequest.globalSecondaryIndices(globalSecondaryIndices.stream()
+                    .map(DynamoDbTableBatchlet::getEnhancedGlobalSecondaryIndex)
+                    .collect(Collectors.toList()));
+        }
+        if (isValidCapacityUnits(writeCapacityUnits) && isValidCapacityUnits(readCapacityUnits)) {
+            createRequest.provisionedThroughput(b ->
+                    b.writeCapacityUnits(writeCapacityUnits).readCapacityUnits(readCapacityUnits));
+        }
+        table.createTable(createRequest.build());
+        client.waiter().waitUntilTableExists(DescribeTableRequest.builder().tableName(tableName).build());
+    }
+
+    private static boolean isValidCapacityUnits(Long capacityUnits) {
+        return capacityUnits != null && capacityUnits > 0;
+    }
+
+    private void doUpdate() {
+        logger.warn("Updating table {}", tableName);
+        String tableArn = null;
+        if (kmsMasterKeyId != null && !kmsMasterKeyId.isEmpty()) {
+            UpdateTableRequest.Builder updateRequest = UpdateTableRequest.builder()
+                    .tableName(tableName);
+            updateRequest = updateRequest.sseSpecification(SSESpecification.builder()
+                    .enabled(true)
+                    .sseType(SSEType.KMS)
+                    .kmsMasterKeyId(kmsMasterKeyId)
+                    .build());
+            UpdateTableResponse updateResponse = client.updateTable(updateRequest.build());
+            tableArn = updateResponse.tableDescription().tableArn();
+        }
+        // Tags
+        if (tableTags != null && !tableTags.isEmpty() && !dynamoDbLocal) {
+            if (tableArn == null) {
+                DescribeTableResponse describeResponse = client.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
+                tableArn = describeResponse.table().tableArn();
+            }
+            List<Tag> tags = tableTags.entrySet().stream()
+                    .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
+                    .collect(Collectors.toList());
+            client.tagResource(TagResourceRequest.builder()
+                    .resourceArn(tableArn)
+                    .tags(tags)
+                    .build());
+        }
+        // Point in time recovery
+        if (pointInTimeRecoveryEnabled != null && !dynamoDbLocal) {
+            client.updateContinuousBackups(UpdateContinuousBackupsRequest.builder()
+                    .tableName(tableName)
+                    .pointInTimeRecoverySpecification(PointInTimeRecoverySpecification.builder()
+                            .pointInTimeRecoveryEnabled(true)
+                            .build())
+                    .build());
+        }
+    }
+
+    private static EnhancedGlobalSecondaryIndex getEnhancedGlobalSecondaryIndex(String indexName) {
+        return EnhancedGlobalSecondaryIndex.builder()
+                .indexName(indexName)
+                .projection(pr -> pr.projectionType(ProjectionType.ALL))
+                .build();
+    }
+}

--- a/src/test/java/org/jberet/support/io/DynamoDbHelper.java
+++ b/src/test/java/org/jberet/support/io/DynamoDbHelper.java
@@ -1,0 +1,100 @@
+package org.jberet.support.io;
+
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assume.assumeTrue;
+
+class DynamoDbHelper {
+    static final String ENDPOINT_URI = "http://localhost:8000";
+    static final String ACCESS_KEY_ID = "JBeret";
+    static final String SECRET_ACCESS_KEY = "JBeret";
+    public static final String TABLE_NAME = "stock_trade";
+    DynamoDbEnhancedClient enhancedClient;
+    DynamoDbTable<StockTradeDynamoDb> table;
+    static Boolean available = null;
+
+    public static boolean isDynamoDbLocalAvailable() {
+        if (available == null) {
+            try {
+                HttpURLConnection connection = (HttpURLConnection) new URL(ENDPOINT_URI).openConnection();
+                connection.setConnectTimeout(1000);
+                available = connection.getResponseCode() > 0 && connection.getResponseCode() < 600;
+            } catch (IOException e) {
+                available = false;
+            }
+        }
+        return available;
+    }
+
+    public static void assumeDynamoDbLocalAvailable() {
+        assumeTrue("DynamoDB local should be running and listening at " + ENDPOINT_URI, DynamoDbHelper.isDynamoDbLocalAvailable());
+    }
+
+    public void setUp() {
+        if (!isDynamoDbLocalAvailable()) {
+            return;
+        }
+        enhancedClient = DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(DynamoDbClient.builder()
+                        .endpointOverride(URI.create(ENDPOINT_URI))
+                        .credentialsProvider(() -> AwsBasicCredentials.create(ACCESS_KEY_ID, SECRET_ACCESS_KEY))
+                        .region(Region.EU_WEST_1)
+                        .build()
+                ).build();
+        table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(StockTradeDynamoDb.class));
+        try {
+            table.createTable();
+        } catch (DynamoDbException e) {
+            // Table already exists
+        }
+    }
+
+    public void tearDown() {
+        if (!isDynamoDbLocalAvailable()) {
+            return;
+        }
+        try {
+            table.deleteTable();
+        } catch (DynamoDbException e) {
+            // Table does not exist
+        }
+    }
+
+    static List<StockTradeDynamoDb> loadItems(int limit) {
+        try (Stream<String> lineStream = Files.lines(Path.of(StockTradeDynamoDb.class.getResource("/IBM_unadjusted.txt").toURI()))) {
+            return lineStream
+                    .filter(StringUtils::isNotBlank)
+                    .map(StockTradeDynamoDb::parseCsv)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalStateException("Failed to load IBM_unadjusted.txt");
+        }
+    }
+
+    public DynamoDbEnhancedClient getEnhancedClient() {
+        return enhancedClient;
+    }
+
+    public DynamoDbTable<StockTradeDynamoDb> getTable() {
+        return table;
+    }
+}

--- a/src/test/java/org/jberet/support/io/DynamoDbItemReaderTest.java
+++ b/src/test/java/org/jberet/support/io/DynamoDbItemReaderTest.java
@@ -1,0 +1,220 @@
+package org.jberet.support.io;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.runtime.BatchRuntime;
+import jakarta.batch.runtime.BatchStatus;
+import org.jberet.runtime.JobExecutionImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.jberet.support.io.DynamoDbHelper.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link DynamoDbItemReader}.
+ * This test requires a DynamoDB local to be running.
+ *
+ * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html">DynamoDBLocal Guide</a>
+ * @see <a href="https://hub.docker.com/r/amazon/dynamodb-local">DynamoDBLocal Docker image</a>
+ */
+public class DynamoDbItemReaderTest {
+	static final String DATE_KEY = "01/02/1998";
+	static final JobOperator jobOperator = BatchRuntime.getJobOperator();
+	final DynamoDbHelper helper = new DynamoDbHelper();
+
+	@Before
+	public void setUp() {
+		helper.setUp();
+	}
+
+	private List<StockTradeDynamoDb> loadItems(int limit) {
+		List<StockTradeDynamoDb> loadedItems = DynamoDbHelper.loadItems(limit);
+		loadedItems.forEach(item -> helper.getTable().putItem(item));
+		return loadedItems;
+	}
+
+	@After
+	public void tearDown() {
+		helper.tearDown();
+	}
+
+	static DynamoDbItemReader<StockTradeDynamoDb> createReader() {
+		DynamoDbItemReader<StockTradeDynamoDb> reader = new DynamoDbItemReader<>();
+		reader.endpointUri = ENDPOINT_URI;
+		reader.accessKeyId = ACCESS_KEY_ID;
+		reader.secretAccessKey = SECRET_ACCESS_KEY;
+		reader.region = Region.EU_WEST_1.id();
+		reader.tableName = TABLE_NAME;
+		reader.beanClass = StockTradeDynamoDb.class;
+		return reader;
+	}
+
+	private static List<StockTradeDynamoDb> readAll(DynamoDbItemReader<StockTradeDynamoDb> reader) {
+		List<StockTradeDynamoDb> readItems = new ArrayList<>();
+		StockTradeDynamoDb readItem;
+		while ((readItem = reader.readItem()) != null) {
+			readItems.add(readItem);
+		}
+		return readItems;
+	}
+
+	@Test
+	public void testReadItemsWithScan() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(123);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(loadedItems, readItems);
+	}
+
+	@Test
+	public void testReadItemsWithScanAndBounds() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(60);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.start=10;
+		reader.end=20;
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(10, readItems.size());
+	}
+
+	@Test
+	public void testReadItemsWithScanAndProject() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(12);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.attributesToProject="dateKey,time,volume";
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(12, readItems.size());
+		for(StockTradeDynamoDb item: readItems) {
+			// Fetched
+			assertNotNull(item.getDateKey());
+			assertNotNull(item.getTime());
+			assertNotEquals(0.0D, item.getVolume(), 0.1D);
+			// Not fetched
+			assertEquals(0.0D, item.getHigh(), 0.1D);
+			assertEquals(0.0D, item.getLow(), 0.1D);
+		}
+	}
+
+	@Test
+	public void testReadItemsWithScanAndFilter() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(105);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.filterExpression = "volume >= :minVolume";
+		reader.filterExpressionValues = "{\":minVolume\":10000}";
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(loadedItems.stream().filter(i -> i.getVolume() >= 10000).collect(Collectors.toList()), readItems);
+	}
+
+	@Test
+	public void testReadItemsWithQuery() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(134);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.partitionKey = DATE_KEY;
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(loadedItems.stream().filter(i -> i.getDateKey().equals(DATE_KEY)).collect(Collectors.toList()), readItems);
+	}
+
+	@Test
+	public void testReadItemsWithQueryAndFilter() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(151);
+		// Initialize Reader
+		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
+		reader.partitionKey = DATE_KEY;
+		reader.filterExpression = "volume >= :minVolume";
+		reader.filterExpressionValues = "{\":minVolume\":10000}";
+		reader.open(null);
+
+		// Read items to dynamo
+		List<StockTradeDynamoDb> readItems = readAll(reader);
+
+		// Check dynamo content
+		assertEquals(loadedItems.stream().filter(i -> i.getDateKey().equals(DATE_KEY) && i.getVolume() >= 10000).collect(Collectors.toList()), readItems);
+	}
+
+	/**
+	 * Run Job in org.jberet.support.io.DynamoDbReaderTest.xml
+	 */
+	void runJob(int start, int end) throws Exception {
+		Properties jobParams = new Properties();
+		jobParams.setProperty("start", String.valueOf(start));
+		jobParams.setProperty("end", String.valueOf(end));
+		final long jobExecutionId = jobOperator.start("org.jberet.support.io.DynamoDbReaderTest", jobParams);
+		final JobExecutionImpl jobExecution = (JobExecutionImpl) jobOperator.getJobExecution(jobExecutionId);
+		jobExecution.awaitTermination(1, TimeUnit.MINUTES);
+		assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+	}
+
+	@Test
+	public void testRunReadJob() throws Exception {
+		assumeDynamoDbLocalAvailable();
+		List<StockTradeDynamoDb> loadedItems = loadItems(321);
+		// Run job
+		runJob(0, 321);
+	}
+
+	@Test
+	public void testGetAttributeValues() throws JsonProcessingException {
+		ObjectNode objectNode = (ObjectNode) new ObjectMapper()
+				.readTree("{\":number\":12,\":boolean\":true,\":string\":\"candy\",\":null\": null,\":array\":[1,2,3],\":object\":{\"a\":1,\"b\":2}}");
+		Map<String, AttributeValue> attributeValues = DynamoDbItemReader.getAttributeValues(objectNode);
+		assertEquals(12, Integer.parseInt(attributeValues.get(":number").n()));
+		assertTrue(attributeValues.get(":boolean").bool().booleanValue());
+		assertEquals("candy", attributeValues.get(":string").s());
+		assertTrue(attributeValues.get(":null").nul().booleanValue());
+		assertEquals(Arrays.asList(1,2,3), attributeValues.get(":array").l().stream().map(AttributeValue::n).map(Integer::parseInt).collect(Collectors.toList()));
+		Map<String, Integer> map = attributeValues.get(":object").m().entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> Integer.valueOf(e.getValue().n())));
+		assertEquals(2, map.size());
+		assertEquals(1, map.get("a").intValue());
+		assertEquals(2, map.get("b").intValue());
+	}
+
+}

--- a/src/test/java/org/jberet/support/io/DynamoDbItemReaderTest.java
+++ b/src/test/java/org/jberet/support/io/DynamoDbItemReaderTest.java
@@ -13,11 +13,7 @@ import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -39,12 +35,7 @@ public class DynamoDbItemReaderTest {
 	@Before
 	public void setUp() {
 		helper.setUp();
-	}
-
-	private List<StockTradeDynamoDb> loadItems(int limit) {
-		List<StockTradeDynamoDb> loadedItems = DynamoDbHelper.loadItems(limit);
-		loadedItems.forEach(item -> helper.getTable().putItem(item));
-		return loadedItems;
+        helper.createTable();
 	}
 
 	@After
@@ -75,7 +66,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithScan() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(123);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(123);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.open(null);
@@ -90,7 +81,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithScanAndBounds() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(60);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(60);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.start=10;
@@ -107,7 +98,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithScanAndProject() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(12);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(12);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.attributesToProject="dateKey,time,volume";
@@ -132,7 +123,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithScanAndFilter() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(105);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(105);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.filterExpression = "volume >= :minVolume";
@@ -149,7 +140,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithQuery() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(134);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(134);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.partitionKey = DATE_KEY;
@@ -165,7 +156,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testReadItemsWithQueryAndFilter() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(151);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(151);
 		// Initialize Reader
 		DynamoDbItemReader<StockTradeDynamoDb> reader = createReader();
 		reader.partitionKey = DATE_KEY;
@@ -196,7 +187,7 @@ public class DynamoDbItemReaderTest {
 	@Test
 	public void testRunReadJob() throws Exception {
 		assumeDynamoDbLocalAvailable();
-		List<StockTradeDynamoDb> loadedItems = loadItems(321);
+        List<StockTradeDynamoDb> loadedItems = helper.loadAndPutItems(321);
 		// Run job
 		runJob(0, 321);
 	}

--- a/src/test/java/org/jberet/support/io/DynamoDbItemWriterTest.java
+++ b/src/test/java/org/jberet/support/io/DynamoDbItemWriterTest.java
@@ -1,0 +1,112 @@
+package org.jberet.support.io;
+
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.runtime.BatchRuntime;
+import jakarta.batch.runtime.BatchStatus;
+import org.jberet.runtime.JobExecutionImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.jberet.support.io.DynamoDbHelper.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link DynamoDbItemWriter}
+ * This test requires a DynamoDB local to be running.
+ *
+ * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html">DynamoDBLocal Guide</a>
+ * @see <a href="https://hub.docker.com/r/amazon/dynamodb-local">DynamoDBLocal Docker image</a>
+ */
+public class DynamoDbItemWriterTest {
+    static final JobOperator jobOperator = BatchRuntime.getJobOperator();
+    final DynamoDbHelper helper = new DynamoDbHelper();
+
+
+    @Before
+    public void setUp() {
+        helper.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    @Test
+    public void testWriteItems() {
+        assumeDynamoDbLocalAvailable();
+        // Initialize writer
+        DynamoDbItemWriter<StockTradeDynamoDb> writer = new DynamoDbItemWriter<>();
+        writer.endpointUri = ENDPOINT_URI;
+        writer.accessKeyId = ACCESS_KEY_ID;
+        writer.secretAccessKey = SECRET_ACCESS_KEY;
+        writer.region = Region.EU_WEST_1.id();
+        writer.tableName = TABLE_NAME;
+        writer.beanClass = StockTradeDynamoDb.class;
+        writer.open(null);
+
+        // Load items CSV file
+        List<StockTradeDynamoDb> items = loadItems(128);
+
+        // Write items to dynamo
+        writer.writeItems(items.stream().map(Object.class::cast).collect(Collectors.toList()));
+
+        // Check dynamo content
+        assertEquals(items.size(), helper.getTable().scan().items().stream().count());
+    }
+
+	@Test
+	public void testDeleteItems() {
+		assumeDynamoDbLocalAvailable();
+		// Initialize writer
+		DynamoDbItemWriter<StockTradeDynamoDb> writer = new DynamoDbItemWriter<>();
+		writer.endpointUri = ENDPOINT_URI;
+		writer.accessKeyId = ACCESS_KEY_ID;
+		writer.secretAccessKey = SECRET_ACCESS_KEY;
+		writer.region = Region.EU_WEST_1.id();
+		writer.tableName = TABLE_NAME;
+		writer.beanClass = StockTradeDynamoDb.class;
+		writer.deleteItem = true;
+		writer.open(null);
+
+		// Load items CSV file
+		List<StockTradeDynamoDb> items = loadItems(32);
+		items.forEach(helper.getTable()::putItem);
+
+		// Delete items from dynamo
+		writer.writeItems(items.stream().map(Object.class::cast).collect(Collectors.toList()));
+
+
+		// Check dynamo content
+		assertEquals(0, helper.getTable().scan().items().stream().count());
+	}
+
+    void runJob(int start, int end) throws Exception {
+        Properties jobParams = new Properties();
+        jobParams.setProperty("start", String.valueOf(start));
+        jobParams.setProperty("end", String.valueOf(end));
+        final long jobExecutionId = jobOperator.start("org.jberet.support.io.DynamoDbWriterTest", jobParams);
+        final JobExecutionImpl jobExecution = (JobExecutionImpl) jobOperator.getJobExecution(jobExecutionId);
+        jobExecution.awaitTermination(1, TimeUnit.MINUTES);
+        assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+    }
+
+    @Test
+    public void testRunWriteJob() throws Exception {
+        assumeDynamoDbLocalAvailable();
+        // Run job
+        // See org.jberet.support.io.DynamoDbWriterTest.xml
+        runJob(0, 321);
+
+        // Check dynamo content
+        assertEquals(321, helper.getTable().scan().items().stream().count());
+    }
+
+}

--- a/src/test/java/org/jberet/support/io/DynamoDbTableBatchletTest.java
+++ b/src/test/java/org/jberet/support/io/DynamoDbTableBatchletTest.java
@@ -1,0 +1,117 @@
+package org.jberet.support.io;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+
+import static org.jberet.support.io.DynamoDbHelper.*;
+import static org.junit.Assert.assertEquals;
+
+public class DynamoDbTableBatchletTest {
+
+    final DynamoDbHelper helper = new DynamoDbHelper();
+
+    @Before
+    public void setUp() {
+        helper.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    private TableDescription describeTable() {
+        return helper.client.describeTable(DescribeTableRequest.builder().tableName(DynamoDbHelper.TABLE_NAME).build()).table();
+    }
+
+    private DynamoDbTableBatchlet<StockTradeDynamoDb> newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action action) {
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = new DynamoDbTableBatchlet<>();
+        batchlet.endpointUri = ENDPOINT_URI;
+        batchlet.accessKeyId = ACCESS_KEY_ID;
+        batchlet.secretAccessKey = SECRET_ACCESS_KEY;
+        batchlet.region = Region.EU_WEST_1.id();
+        batchlet.tableName = TABLE_NAME;
+        batchlet.beanClass = StockTradeDynamoDb.class;
+        batchlet.action = action.name();
+        return batchlet;
+    }
+
+    @Test
+    public void create() {
+        // Given
+        helper.deleteTable();
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.CREATE);
+        // When
+        batchlet.process();
+        // Then
+        TableDescription tableDescription = describeTable();
+        assertEquals(TABLE_NAME, tableDescription.tableName());
+        assertEquals(BillingMode.PAY_PER_REQUEST, tableDescription.billingModeSummary().billingMode());
+    }
+
+    @Test
+    public void createProvisioned() {
+        // Given
+        helper.deleteTable();
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.CREATE);
+        batchlet.readCapacityUnits = 2L;
+        batchlet.writeCapacityUnits = 1L;
+        // When
+        batchlet.process();
+        // Then
+        TableDescription tableDescription = describeTable();
+        assertEquals(TABLE_NAME, tableDescription.tableName());
+        assertEquals(2L, tableDescription.provisionedThroughput().readCapacityUnits().longValue());
+        assertEquals(1L, tableDescription.provisionedThroughput().writeCapacityUnits().longValue());
+        //assertEquals(BillingMode.PROVISIONED, tableDescription.billingModeSummary().billingMode());
+    }
+
+    @Test
+    public void createTwice() {
+        // Given
+        helper.deleteTable();
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.CREATE);
+        batchlet.process();
+        // When
+        batchlet.process();
+        // Then
+        TableDescription tableDescription = describeTable();
+        assertEquals(TABLE_NAME, tableDescription.tableName());
+    }
+
+    @Test
+    public void update() {
+        // Given
+        helper.deleteTable();
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.CREATE);
+        batchlet.process();
+        // When
+        batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.UPDATE);
+        batchlet.process();
+        // Then
+        TableDescription tableDescription = describeTable();
+        assertEquals(TABLE_NAME, tableDescription.tableName());
+    }
+
+    @Test
+    public void truncate() {
+        // Given
+        helper.deleteTable();
+        DynamoDbTableBatchlet<StockTradeDynamoDb> batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.CREATE);
+        batchlet.process();
+
+        helper.loadAndPutItems(12);
+        assertEquals(12, helper.getTable().scan().items().stream().count());
+        // When
+        batchlet = newDynamoDbTableBatchlet(DynamoDbTableBatchlet.Action.TRUNCATE);
+        batchlet.process();
+        // Then
+        assertEquals(0, helper.getTable().scan().items().stream().count());
+    }
+
+}

--- a/src/test/java/org/jberet/support/io/StockTradeDynamoDb.java
+++ b/src/test/java/org/jberet/support/io/StockTradeDynamoDb.java
@@ -1,0 +1,59 @@
+package org.jberet.support.io;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnore;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * {@link StockTrade} implementation enriched with DynamoDB mapping annotations.
+ */
+@DynamoDbBean
+public class StockTradeDynamoDb extends StockTrade {
+    @DynamoDbIgnore
+    @Override
+    public Date getDate() {
+        return super.getDate();
+    }
+
+    @DynamoDbPartitionKey
+    public String getDateKey() {
+        return getDateFormat().format(getDate());
+    }
+
+    public void setDateKey(String s) {
+        try {
+            setDate(getDateFormat().parse(s));
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Invalid date " + s);
+        }
+    }
+
+    private static DateFormat getDateFormat() {
+        return new SimpleDateFormat("MM/dd/yyyy");
+    }
+
+    @DynamoDbSortKey
+    @Override
+    public String getTime() {
+        return super.getTime();
+    }
+
+    public static StockTradeDynamoDb parseCsv(String csvLine) {
+        String[] cells = csvLine.split(",", 7);
+        StockTradeDynamoDb item = new StockTradeDynamoDb();
+        item.setDateKey(cells[0]);
+        item.setTime(cells[1]);
+        item.setOpen(Double.parseDouble(cells[2]));
+        item.setHigh(Double.parseDouble(cells[3]));
+        item.setLow(Double.parseDouble(cells[4]));
+        item.setClose(Double.parseDouble(cells[5]));
+        item.setVolume(Double.parseDouble(cells[6]));
+        return item;
+    }
+}

--- a/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbReaderTest.xml
+++ b/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbReaderTest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright (c) 2018 Red Hat, Inc. and/or its affiliates.
+
+ This program and the accompanying materials are made
+ available under the terms of the Eclipse Public License 2.0
+ which is available at https://www.eclipse.org/legal/epl-2.0/
+
+ SPDX-License-Identifier: EPL-2.0
+-->
+
+<job id="org.jberet.support.io.DynamoDbReaderTest" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"
+     version="2.0">
+    <step id="org.jberet.support.io.DynamoDbReaderTest.step1">
+        <chunk item-count="100">
+            <reader ref="dynamoDbItemReader">
+                <properties>
+                    <property name="endpointUri" value="http://localhost:8000"/>
+                    <property name="accessKeyId" value="JBeret"/>
+                    <property name="secretAccessKey" value="JBeret"/>
+                    <property name="tableName" value="stock_trade"/>
+                    <property name="region" value="eu-west-1"/>
+                    <property name="beanClass" value="org.jberet.support.io.StockTradeDynamoDb"/>
+                </properties>
+            </reader>
+            <writer ref="mockItemWriter">
+                <properties>
+                    <property name="toConsole" value="true"/>
+                </properties>
+            </writer>
+        </chunk>
+    </step>
+</job>

--- a/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbWriterTest.xml
+++ b/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbWriterTest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright (c) 2018 Red Hat, Inc. and/or its affiliates.
+
+ This program and the accompanying materials are made
+ available under the terms of the Eclipse Public License 2.0
+ which is available at https://www.eclipse.org/legal/epl-2.0/
+
+ SPDX-License-Identifier: EPL-2.0
+-->
+
+<job id="org.jberet.support.io.DynamoDbWriterTest" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"
+     version="2.0">
+    <step id="org.jberet.support.io.DynamoDbWriterTest.step1">
+        <chunk item-count="100">
+            <reader ref="csvItemReader">
+                <properties>
+                    <property name="resource" value="IBM_unadjusted.txt"/>
+                    <property name="headerless" value="true"/>
+                    <property name="beanType" value="org.jberet.support.io.StockTradeDynamoDb"/>
+                    <property name="start" value="#{jobParameters['start']}"/>
+                    <property name="end" value="#{jobParameters['end']}"/>
+                    <property name="nameMapping" value="Date,Time,Open,High,Low,Close,Volume"/>
+                    <property name="cellProcessors"
+                              value="ParseDate('MM/dd/yyyy');null;ParseDouble;ParseDouble;ParseDouble;ParseDouble;ParseDouble"/>
+                </properties>
+            </reader>
+            <writer ref="dynamoDbItemWriter">
+                <properties>
+                    <property name="endpointUri" value="http://localhost:8000"/>
+                    <property name="accessKeyId" value="JBeret"/>
+                    <property name="secretAccessKey" value="JBeret"/>
+                    <property name="tableName" value="stock_trade"/>
+                    <property name="region" value="eu-west-1"/>
+                    <property name="beanClass" value="org.jberet.support.io.StockTradeDynamoDb"/>
+                </properties>
+            </writer>
+        </chunk>
+    </step>
+</job>

--- a/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbWriterTest.xml
+++ b/src/test/resources/META-INF/batch-jobs/org.jberet.support.io.DynamoDbWriterTest.xml
@@ -14,7 +14,22 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"
      version="2.0">
-    <step id="org.jberet.support.io.DynamoDbWriterTest.step1">
+    <step id="org.jberet.support.io.DynamoDbWriterTest.step1" next="org.jberet.support.io.DynamoDbWriterTest.step2">
+        <batchlet ref="dynamoDbTableBatchlet">
+            <properties>
+                <property name="endpointUri" value="http://localhost:8000"/>
+                <property name="accessKeyId" value="JBeret"/>
+                <property name="secretAccessKey" value="JBeret"/>
+                <property name="tableName" value="stock_trade"/>
+                <property name="region" value="eu-west-1"/>
+                <property name="beanClass" value="org.jberet.support.io.StockTradeDynamoDb"/>
+                <property name="action" value="TRUNCATE"/>
+                <property name="tableTags" value="environment=test,class=StockTrade"/>
+                <property name="dynamoDbLocal" value="true"/>
+            </properties>
+        </batchlet>
+    </step>
+    <step id="org.jberet.support.io.DynamoDbWriterTest.step2">
         <chunk item-count="100">
             <reader ref="csvItemReader">
                 <properties>


### PR DESCRIPTION
DynamoDbItemReader and DynamoDbItemWriter allows to read and write objects to AWS Dynamo DB. 
These implementations are based on AWS SDKv2 for Java and DynamoDB Enhanced client. DynamoDB beans must be annotated with specific annotations.
See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/dynamodb-enhanced-client.html