### PR TITLE
Rename the `default` profile because it's not active by default.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: ${{ matrix.jdk-distribution }}
           java-version: ${{ matrix.jdk-version }}
       - name: Run Tests
-        run: mvn -ntp -U -B -fae clean verify -P default
+        run: mvn -ntp -U -B -fae clean verify -P exclude-failed-tests
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -385,10 +385,7 @@
             </properties>
         </profile>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <id>exclude-failed-tests</id>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Relative Maven issue: https://issues.apache.org/jira/browse/MNG-4917